### PR TITLE
PR-6 :  manage cicd on tag

### DIFF
--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -4,6 +4,9 @@ jobs:
   compilation_and_test:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2 
-    - run: sudo apt-get update && sudo apt-get install -y maven # Installation of maven
-    - run: mvn verify
+    - name : get code
+      uses: actions/checkout@v2 
+    - name : installation of maven
+      run: sudo apt-get update && sudo apt-get install -y maven 
+    - name : compile and run test
+      run: mvn verify

--- a/.github/workflows/push_pull.yml
+++ b/.github/workflows/push_pull.yml
@@ -1,4 +1,4 @@
-name : project_cantina
+name : project_cantina_push_pull
 on : [push, pull_request]
 jobs:
   compilation_and_test:
@@ -6,5 +6,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2 
     - run: sudo apt-get update && sudo apt-get install -y maven # Installation of maven
-    - run: mvn clean
     - run: mvn verify

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,36 @@
+name: project_cantina_tag
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+jobs:
+  publish:
+    runs-on: ubuntu-18.04
+    steps:
+      - name : get code
+        uses : actions/checkout@v2 
+      - name : installation of name
+        run: sudo apt-get update && sudo apt-get install -y maven # Installation of maven
+      - name : compile and run test
+        run: mvn verify
+      - name : release creation
+        id : release_creation
+        uses: actions/create-release@v1
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name : upload jar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release_creation.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./target/cantina.menu-1.0-SNAPSHOT.jar
+          asset_name: cantina.menu.jar
+          asset_content_type: application/java-archive

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - name : get code
         uses : actions/checkout@v2 
-      - name : installation of name
-        run: sudo apt-get update && sudo apt-get install -y maven # Installation of maven
+      - name : installation of maven
+        run: sudo apt-get update && sudo apt-get install -y maven 
       - name : compile and run test
         run: mvn verify
       - name : release creation
@@ -30,7 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.release_creation.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          upload_url: ${{ steps.release_creation.outputs.upload_url }} 
           asset_path: ./target/cantina.menu-1.0-SNAPSHOT.jar
           asset_name: cantina.menu.jar
           asset_content_type: application/java-archive


### PR DESCRIPTION
When a tag is created on the main branch, is released is created with the jar of the application on assets. 

To do that I create a file .github/workflows/tag.yml with the different steps and tag to do that autmaticaly.

I also rename the file .github/workflows/ci_cd.yml by .github/workflows/push_pull.yml and I add name for the task on it.  